### PR TITLE
Fix compile error with reverse loop on beta 0.2.008

### DIFF
--- a/md.jai
+++ b/md.jai
@@ -20,7 +20,7 @@ merkle_damgard :: (data: string, block_size: int) -> blocks: int, padded: string
 
     data_padded[data.count] = 0b10000000; // Start padding with guard byte
 
-    for < length_block-1..0 {
+    for #v2 < 0..length_block-1 {
         idx := data.count+padding_bytes+(length_block-it);
         if it*8 < 64 { // TODO: This is a workaround for a pre-beta Jai issue
                        // where shifts by more than word-length loops back.


### PR DESCRIPTION
Beta 0.2.002 made using < without the #v2 directive an error so on betas. This fixes that so we compile again! 